### PR TITLE
async + retry + simplify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,12 @@ classifiers = [
 
 dependencies = [
     "click>=8.0",
-    "requests>=2.25",
+    "httpx>=0.27",
     "pyyaml>=6.0",
     # krtc requires pykerberos which needs system Kerberos headers to compile.
     # Use UV_PYTHON to point to a conda environment that has krtc pre-installed.
     "pydantic>=2.12.5"
+    "stamina>=25.1.0",
 ]
 
 [dependency-groups]

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -7,10 +7,11 @@ import subprocess
 from typing import Any, TypeVar
 
 import httpx
+import stamina
 from krtc import KerberosTicket
 from pydantic import BaseModel
 
-from ..exceptions import APIError, AuthenticationError, TransientError
+from ..exceptions import AuthenticationError
 from ..utils import get_logger
 from .gen.endpoint import Endpoint
 from .gen.endpoint_models import (
@@ -39,12 +40,17 @@ DEFAULT_BASE_URL = "https://pswww.slac.stanford.edu"
 DEFAULT_KERBEROS_PRINCIPAL = "HTTP@pswww.slac.stanford.edu"
 
 # Retry configuration
-RETRY_MAX_ATTEMPTS = 3
-RETRY_BASE_DELAY = 2.0
 REQUEST_TIMEOUT = 30
-TRANSIENT_STATUS_CODES = {500, 502, 503, 504}
 
 M = TypeVar("M", bound=BaseModel)
+
+
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, (httpx.TimeoutException, httpx.ConnectError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    return False
 
 
 class ElogClient:
@@ -111,13 +117,16 @@ class ElogClient:
         except Exception as e:
             raise AuthenticationError(f"Failed to get Kerberos ticket: {e}") from e
 
+    @stamina.retry(on=_is_retryable)
     async def get(
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
         require_auth: bool = True,
     ) -> dict[str, Any]:
-        """Make a GET request to the API with retry logic.
+        """Make a GET request to the API.
+
+        Transient errors (5xx, network) are retried automatically via stamina.
 
         Args:
             endpoint: API endpoint (relative to base URL)
@@ -128,79 +137,31 @@ class ElogClient:
             JSON response from the API
 
         Raises:
-            APIError: If the request fails after retries
-            TransientError: If transient errors persist after retries
+            APIError: If the request fails with a non-retryable error
             AuthenticationError: If authentication fails
         """
         url = f"{self.base_url}{endpoint}"
         headers = await self._get_auth_headers() if require_auth else {}
+        response = await self._session.get(url, headers=headers, params=params)
 
-        for attempt in range(RETRY_MAX_ATTEMPTS):
-            try:
-                response = await self._session.get(url, headers=headers, params=params)
+        # On 401, refresh the Kerberos ticket and retry once
+        if response.status_code == 401 and require_auth:
+            logger.debug(f"Got 401 for {endpoint}, refreshing auth headers")
+            self._auth_headers = None
+            headers = await self._get_auth_headers()
+            response = await self._session.get(url, headers=headers, params=params)
+            if response.status_code == 401:
+                raise AuthenticationError(
+                    f"Access denied for {endpoint}. Check if you have permission."
+                )
 
-                # On 401, try refreshing the Kerberos ticket once
-                if response.status_code == 401 and require_auth:
-                    logger.debug(f"Got 401 for {endpoint}, refreshing auth headers")
-                    self._auth_headers = None
-                    headers = await self._get_auth_headers()
-                    response = await self._session.get(
-                        url, headers=headers, params=params
-                    )
+        if response.status_code == 403:
+            raise AuthenticationError(
+                f"Access denied to {endpoint}. You may not have permission."
+            )
 
-                    if response.status_code == 401:
-                        raise AuthenticationError(
-                            f"Access denied for {endpoint}. Check if you have permission."
-                        )
-
-                if response.status_code == 403:
-                    raise AuthenticationError(
-                        f"Access denied to {endpoint}. You may not have permission."
-                    )
-
-                # Check for transient errors (5xx)
-                if response.status_code in TRANSIENT_STATUS_CODES:
-                    if attempt < RETRY_MAX_ATTEMPTS - 1:
-                        delay = RETRY_BASE_DELAY * (2**attempt)
-                        logger.debug(
-                            f"Got {response.status_code} for {endpoint}, "
-                            f"retrying in {delay}s (attempt {attempt + 1}/{RETRY_MAX_ATTEMPTS})"
-                        )
-                        await asyncio.sleep(delay)
-                        continue
-                    raise TransientError(
-                        f"Server error after {RETRY_MAX_ATTEMPTS} attempts: {response.status_code}",
-                        status_code=response.status_code,
-                        response=response.text[:500],
-                    )
-
-                if not response.is_success:
-                    raise APIError(
-                        f"API request failed: {response.status_code}",
-                        status_code=response.status_code,
-                        response=response.text[:500],
-                    )
-
-                return response.json()
-
-            except (httpx.TimeoutException, httpx.ConnectError) as e:
-                if attempt < RETRY_MAX_ATTEMPTS - 1:
-                    delay = RETRY_BASE_DELAY * (2**attempt)
-                    logger.debug(
-                        f"Network error for {endpoint}: {e}, "
-                        f"retrying in {delay}s (attempt {attempt + 1}/{RETRY_MAX_ATTEMPTS})"
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-                raise TransientError(
-                    f"Network error after {RETRY_MAX_ATTEMPTS} attempts: {e}"
-                ) from e
-
-            except httpx.RequestError as e:
-                raise APIError(f"Network error: {e}") from e
-
-        # unreachable, but satisfies type checker
-        raise APIError(f"Failed to GET {endpoint} after {RETRY_MAX_ATTEMPTS} attempts")
+        response.raise_for_status()
+        return response.json()
 
     async def get_public(
         self,

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
-import time
 from typing import Any, TypeVar
 
-import requests
+import httpx
 from krtc import KerberosTicket
 from pydantic import BaseModel
 
@@ -48,7 +48,7 @@ M = TypeVar("M", bound=BaseModel)
 
 
 class ElogClient:
-    """HTTP client for SLAC elog API with Kerberos authentication."""
+    """Async HTTP client for SLAC elog API with Kerberos authentication."""
 
     def __init__(
         self,
@@ -64,10 +64,16 @@ class ElogClient:
         self.base_url = base_url or DEFAULT_BASE_URL
         self.kerberos_principal = kerberos_principal or DEFAULT_KERBEROS_PRINCIPAL
         self._auth_headers: dict[str, str] | None = None
-        self._session = requests.Session()
+        self._session = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
 
-    def _check_kerberos_auth(self) -> bool:
-        """Check if Kerberos authentication is valid."""
+    async def __aenter__(self) -> ElogClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self._session.aclose()
+
+    def _check_kerberos_auth_sync(self) -> bool:
+        """Check if Kerberos authentication is valid (blocking)."""
         try:
             result = subprocess.run(
                 ["klist", "-s"],
@@ -78,7 +84,7 @@ class ElogClient:
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    def _get_auth_headers(self) -> dict[str, str]:
+    async def _get_auth_headers(self) -> dict[str, str]:
         """Get Kerberos authentication headers.
 
         Returns:
@@ -90,21 +96,22 @@ class ElogClient:
         if self._auth_headers is not None:
             return self._auth_headers
 
-        if not self._check_kerberos_auth():
+        valid = await asyncio.to_thread(self._check_kerberos_auth_sync)
+        if not valid:
             raise AuthenticationError(
                 "Kerberos authentication not found or expired. "
                 "Please run 'kinit' to authenticate."
             )
 
         try:
-            self._auth_headers = KerberosTicket(
-                self.kerberos_principal
-            ).getAuthHeaders()
+            self._auth_headers = await asyncio.to_thread(
+                lambda: KerberosTicket(self.kerberos_principal).getAuthHeaders()
+            )
             return self._auth_headers
         except Exception as e:
             raise AuthenticationError(f"Failed to get Kerberos ticket: {e}") from e
 
-    def get(
+    async def get(
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
@@ -126,21 +133,19 @@ class ElogClient:
             AuthenticationError: If authentication fails
         """
         url = f"{self.base_url}{endpoint}"
-        headers = self._get_auth_headers() if require_auth else {}
+        headers = await self._get_auth_headers() if require_auth else {}
 
         for attempt in range(RETRY_MAX_ATTEMPTS):
             try:
-                response = self._session.get(
-                    url, headers=headers, params=params, timeout=REQUEST_TIMEOUT
-                )
+                response = await self._session.get(url, headers=headers, params=params)
 
                 # On 401, try refreshing the Kerberos ticket once
                 if response.status_code == 401 and require_auth:
                     logger.debug(f"Got 401 for {endpoint}, refreshing auth headers")
-                    self._auth_headers = None  # Clear cached headers
-                    headers = self._get_auth_headers()  # Get fresh headers
-                    response = self._session.get(
-                        url, headers=headers, params=params, timeout=REQUEST_TIMEOUT
+                    self._auth_headers = None
+                    headers = await self._get_auth_headers()
+                    response = await self._session.get(
+                        url, headers=headers, params=params
                     )
 
                     if response.status_code == 401:
@@ -161,7 +166,7 @@ class ElogClient:
                             f"Got {response.status_code} for {endpoint}, "
                             f"retrying in {delay}s (attempt {attempt + 1}/{RETRY_MAX_ATTEMPTS})"
                         )
-                        time.sleep(delay)
+                        await asyncio.sleep(delay)
                         continue
                     raise TransientError(
                         f"Server error after {RETRY_MAX_ATTEMPTS} attempts: {response.status_code}",
@@ -169,7 +174,7 @@ class ElogClient:
                         response=response.text[:500],
                     )
 
-                if not response.ok:
+                if not response.is_success:
                     raise APIError(
                         f"API request failed: {response.status_code}",
                         status_code=response.status_code,
@@ -178,26 +183,26 @@ class ElogClient:
 
                 return response.json()
 
-            except (
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectionError,
-            ) as e:
+            except (httpx.TimeoutException, httpx.ConnectError) as e:
                 if attempt < RETRY_MAX_ATTEMPTS - 1:
                     delay = RETRY_BASE_DELAY * (2**attempt)
                     logger.debug(
                         f"Network error for {endpoint}: {e}, "
                         f"retrying in {delay}s (attempt {attempt + 1}/{RETRY_MAX_ATTEMPTS})"
                     )
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                     continue
                 raise TransientError(
                     f"Network error after {RETRY_MAX_ATTEMPTS} attempts: {e}"
                 ) from e
 
-            except requests.exceptions.RequestException as e:
+            except httpx.RequestError as e:
                 raise APIError(f"Network error: {e}") from e
 
-    def get_public(
+        # unreachable, but satisfies type checker
+        raise APIError(f"Failed to GET {endpoint} after {RETRY_MAX_ATTEMPTS} attempts")
+
+    async def get_public(
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
@@ -211,9 +216,9 @@ class ElogClient:
         Returns:
             JSON response from the API
         """
-        return self.get(endpoint, params=params, require_auth=False)
+        return await self.get(endpoint, params=params, require_auth=False)
 
-    def fetch(
+    async def fetch(
         self,
         endpoint: Endpoint[M],
         params: dict[str, Any] | None = None,
@@ -231,34 +236,35 @@ class ElogClient:
         """
         url = endpoint.url(**path_params)
         data = (
-            self.get(url, params=params)
+            await self.get(url, params=params)
             if endpoint.require_auth
-            else self.get_public(url, params=params)
+            else await self.get_public(url, params=params)
         )
         return endpoint.model.model_validate(data)
 
-    def get_files(self, experiment_id: str) -> FilesResponse:
-        return self.fetch(FILES, experiment_name=experiment_id)
+    async def get_files(self, experiment_id: str) -> FilesResponse:
+        return await self.fetch(FILES, experiment_name=experiment_id)
 
-    def get_experiments(self, offset_secs: int) -> ExperimentNamesUpdatedWithinResponse:
-        return self.fetch(
+    async def get_experiments(
+        self, offset_secs: int
+    ) -> ExperimentNamesUpdatedWithinResponse:
+        return await self.fetch(
             EXPERIMENT_NAMES_UPDATED_WITHIN, params={"offset_secs": offset_secs}
         )
 
-    def get_experiment_info(self, experiment_id: str) -> InfoResponse:
-        return self.fetch(EXPERIMENT_INFO, experiment_name=experiment_id)
+    async def get_experiment_info(self, experiment_id: str) -> InfoResponse:
+        return await self.fetch(EXPERIMENT_INFO, experiment_name=experiment_id)
 
-    def get_elog(self, experiment_id: str) -> ElogResponse:
-        return self.fetch(ELOG, experiment_name=experiment_id)
+    async def get_elog(self, experiment_id: str) -> ElogResponse:
+        return await self.fetch(ELOG, experiment_name=experiment_id)
 
-    def get_runs(self, experiment_id: str) -> RunsResponse:
-        return self.fetch(RUNS, experiment_name=experiment_id)
+    async def get_runs(self, experiment_id: str) -> RunsResponse:
+        return await self.fetch(RUNS, experiment_name=experiment_id)
 
-    def get_run(self, experiment_id: str, run_num: int | str) -> SingleRunResponse:
-        return self.fetch(RUN, experiment_name=experiment_id, run_num=run_num)
+    async def get_run(
+        self, experiment_id: str, run_num: int | str
+    ) -> SingleRunResponse:
+        return await self.fetch(RUN, experiment_name=experiment_id, run_num=run_num)
 
-    def get_workflows(self, experiment_id: str) -> WorkflowDefinitionsResponse:
-        return self.fetch(WORKFLOW_DEFS, experiment_name=experiment_id)
-
-    # def get_questionnaire(self, experiment_id: str) -> QuestionnaireResponse:
-    #     return fetch_questionnaire(self, experiment_id)
+    async def get_workflows(self, experiment_id: str) -> WorkflowDefinitionsResponse:
+        return await self.fetch(WORKFLOW_DEFS, experiment_name=experiment_id)

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -71,6 +71,7 @@ class ElogClient:
         self.kerberos_principal = kerberos_principal or DEFAULT_KERBEROS_PRINCIPAL
         self._auth_headers: dict[str, str] | None = None
         self._session = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
+        self._sync_session = httpx.Client(timeout=REQUEST_TIMEOUT)
 
     async def __aenter__(self) -> ElogClient:
         return self
@@ -163,22 +164,6 @@ class ElogClient:
         response.raise_for_status()
         return response.json()
 
-    async def get_public(
-        self,
-        endpoint: str,
-        params: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Make an unauthenticated GET request.
-
-        Args:
-            endpoint: API endpoint (relative to base URL)
-            params: Query parameters
-
-        Returns:
-            JSON response from the API
-        """
-        return await self.get(endpoint, params=params, require_auth=False)
-
     async def fetch(
         self,
         endpoint: Endpoint[M],
@@ -196,11 +181,7 @@ class ElogClient:
             Validated Pydantic model instance
         """
         url = endpoint.url(**path_params)
-        data = (
-            await self.get(url, params=params)
-            if endpoint.require_auth
-            else await self.get_public(url, params=params)
-        )
+        data = await self.get(url, params=params, require_auth=endpoint.require_auth)
         return endpoint.model.model_validate(data)
 
     async def get_files(self, experiment_id: str) -> FilesResponse:

--- a/src/elogfetch/api/experiments.py
+++ b/src/elogfetch/api/experiments.py
@@ -30,7 +30,7 @@ def fetch_updated_experiments(
 
     logger.info(f"Fetching experiments updated in last {offset_secs} seconds...")
 
-    data = client.get_public(endpoint, params=params)
+    data = client.get(endpoint, params=params, require_auth=False)
 
     # Extract experiment names from the response
     if isinstance(data, dict) and "value" in data:


### PR DESCRIPTION
make the client async and use stamina for retries. if we can help it, best to do retries with this lib rather than rolling our own.

in another PR in this stack (gssapi) we change back the client to sync. i couldn’t unpick the changes easily after i got there

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #13 
- <kbd>&nbsp;10&nbsp;</kbd> #12 
- <kbd>&nbsp;9&nbsp;</kbd> #11 
- <kbd>&nbsp;8&nbsp;</kbd> #10 
- <kbd>&nbsp;7&nbsp;</kbd> #9 
- <kbd>&nbsp;6&nbsp;</kbd> #8 
- <kbd>&nbsp;5&nbsp;</kbd> #7 
- <kbd>&nbsp;4&nbsp;</kbd> #6 
- <kbd>&nbsp;3&nbsp;</kbd> #5 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #3 
- <kbd>&nbsp;1&nbsp;</kbd> #2 
<!-- GitButler Footer Boundary Bottom -->

