### PR TITLE
use well-maintained gssapi instead of `pykerberos/lcls-krtc` for kerberos token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 .venv/
 venv/
 ENV/
+.krb5/
 
 # Environment config
 .env

--- a/README.md
+++ b/README.md
@@ -2,50 +2,35 @@
 
 Fetch LCLS experiment data from the electronic logbook (elog) system and store it in a local SQLite database.
 
-## Installation
+## Prerequisites
 
-This package requires `krtc` which is only available in SLAC conda environments.
+- Python 3.10+
+- `mamba` or `conda` (build-time only, for krb5 headers)
+- SLAC Kerberos credentials (prompted automatically on first use)
 
-### Setup
+## Installation on S3DF
 
-1. Create a `.env` file from the template:
+Authentication uses the `gssapi` package, which can be compiled if we have `krb5-config` binary in our path + related headers `gssapi`-related shared libs. On S3DF we do not have the `krb5-devel` package installed, so that binary is not present. However the `krb5` conda package has that binary, so we can create a minmal conda environment to provide these at build time.
 
-```bash
-cp .env.example .env
-```
-
-1. Edit `.env` to set paths for your environment (`UV_CACHE_DIR` and `UV_PYTHON`)
-
-2. Create a virtual environment and install:
+1. Create a minimal conda environment with the krb5 headers:
 
 ```bash
-set -a; source .env; set +a
-uv venv --python $UV_PYTHON --system-site-packages
-unset UV_PYTHON  # so uv pip targets .venv, not the conda env
-uv pip install -e .
+cd elogfetch
+mamba create --prefix $(pwd)/.krb5 krb5
 ```
 
-1. Activate the environment:
+1. Install dependencies, pointing `gssapi`'s build to the right place:
+
+```bash
+GSSAPI_KRB5CONFIG=$(pwd)/.krb5/bin/krb5-config \
+GSSAPI_MAIN_LIB=/usr/lib64/libgssapi_krb5.so.2 \
+uv sync
+```
+
+1. Activate the virtual environment:
 
 ```bash
 source .venv/bin/activate
-```
-
-### Available conda environments with krtc
-
-```bash
-ls /sdf/group/lcls/ds/ana/sw/conda1/inst/envs/
-```
-
-## Prerequisites
-
-- Valid Kerberos ticket for SLAC authentication
-- Python 3.9+ (from a SLAC conda environment with `krtc`)
-
-Before using, authenticate with Kerberos:
-
-```bash
-kinit
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ dependencies = [
     "click>=8.0",
     "httpx>=0.27",
     "pyyaml>=6.0",
-    # krtc requires pykerberos which needs system Kerberos headers to compile.
-    # Use UV_PYTHON to point to a conda environment that has krtc pre-installed.
-    "pydantic>=2.12.5"
+    "pydantic>=2.12.5",
+    # we use gssapi here directly to use our local ticket
+    "gssapi>=1.8.0",
     "sqlmodel>=0.0.37",
     "stamina>=25.1.0",
     "psycopg[binary]<4.0.0,>=3.1.13",

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -126,7 +126,52 @@ class ElogClient:
             ) from e
 
     @stamina.retry(on=_is_retryable)
-    async def get(
+    def get(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        require_auth: bool = True,
+    ) -> dict[str, Any]:
+        """Synchronous GET request for use in ETL and CLI code.
+
+        Mirrors the async get() method but uses a blocking httpx.Client.
+        Transient errors (5xx, network) are retried automatically via stamina.
+
+        Args:
+            endpoint: API endpoint (relative to base URL)
+            params: Query parameters
+            require_auth: Whether to use Kerberos authentication
+
+        Returns:
+            JSON response from the API
+
+        Raises:
+            AuthenticationError: If authentication fails
+        """
+        url = f"{self.base_url}{endpoint}"
+        headers = self._get_auth_headers() if require_auth else {}
+        response = self._sync_session.get(url, headers=headers, params=params)
+
+        if response.status_code == 401 and require_auth:
+            logger.debug(f"Got 401 for {endpoint}, refreshing auth headers")
+            self._auth_headers = None
+            headers = self._get_auth_headers()
+            response = self._sync_session.get(url, headers=headers, params=params)
+            if response.status_code == 401:
+                raise AuthenticationError(
+                    f"Access denied for {endpoint}. Check if you have permission."
+                )
+
+        if response.status_code == 403:
+            raise AuthenticationError(
+                f"Access denied to {endpoint}. You may not have permission."
+            )
+
+        response.raise_for_status()
+        return response.json()
+
+    @stamina.retry(on=_is_retryable)
+    async def get_async(
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
@@ -188,7 +233,7 @@ class ElogClient:
             Validated Pydantic model instance
         """
         url = endpoint.url(**path_params)
-        data = await self.get(
+        data = await self.get_async(
             url, params=params, require_auth=endpoint.require_auth
         )
         return endpoint.model.model_validate(data)

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
+import base64
 import subprocess
 from typing import Any, TypeVar
 
+import gssapi
 import httpx
 import stamina
-from krtc import KerberosTicket
+from gssapi.raw import GSSError
 from pydantic import BaseModel
 
 from ..exceptions import AuthenticationError
@@ -34,6 +35,15 @@ from .gen.models import (
 )
 
 logger = get_logger()
+
+
+def _get_negotiate_token(service: str) -> str:
+    """Generate a Kerberos SPNEGO Negotiate token for the given service principal."""
+    name = gssapi.Name(service, gssapi.NameType.hostbased_service)
+    ctx = gssapi.SecurityContext(name=name, usage="initiate")
+    token = ctx.step()
+    return "Negotiate " + base64.b64encode(token).decode()
+
 
 # Default values (can be overridden via Config)
 DEFAULT_BASE_URL = "https://pswww.slac.stanford.edu"
@@ -79,44 +89,41 @@ class ElogClient:
     async def __aexit__(self, *args: object) -> None:
         await self._session.aclose()
 
-    def _check_kerberos_auth_sync(self) -> bool:
-        """Check if Kerberos authentication is valid (blocking)."""
-        try:
-            result = subprocess.run(
-                ["klist", "-s"],
-                capture_output=True,
-                check=True,
-            )
-            return result.returncode == 0
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return False
-
-    async def _get_auth_headers(self) -> dict[str, str]:
+    def _get_auth_headers(self) -> dict[str, str]:
         """Get Kerberos authentication headers.
 
-        Returns:
-            Dictionary of HTTP headers with Kerberos authentication
+        If no valid ticket exists, runs kinit interactively to prompt the user
+        for their password, then retries.
 
         Raises:
-            AuthenticationError: If Kerberos ticket is not available
+            AuthenticationError: If Kerberos authentication fails even after kinit
         """
         if self._auth_headers is not None:
             return self._auth_headers
 
-        valid = await asyncio.to_thread(self._check_kerberos_auth_sync)
-        if not valid:
-            raise AuthenticationError(
-                "Kerberos authentication not found or expired. "
-                "Please run 'kinit' to authenticate."
-            )
+        try:
+            token = _get_negotiate_token(self.kerberos_principal)
+            self._auth_headers = {"Authorization": token}
+            return self._auth_headers
+        except GSSError:
+            pass
 
         try:
-            self._auth_headers = await asyncio.to_thread(
-                lambda: KerberosTicket(self.kerberos_principal).getAuthHeaders()
-            )
+            subprocess.run(["kinit"], check=True)
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            raise AuthenticationError(
+                "No Kerberos ticket found and kinit failed. "
+                "Please run 'kinit' manually to authenticate."
+            ) from e
+
+        try:
+            token = _get_negotiate_token(self.kerberos_principal)
+            self._auth_headers = {"Authorization": token}
             return self._auth_headers
-        except Exception as e:
-            raise AuthenticationError(f"Failed to get Kerberos ticket: {e}") from e
+        except GSSError as e:
+            raise AuthenticationError(
+                f"Kerberos authentication failed after kinit. ({e})"
+            ) from e
 
     @stamina.retry(on=_is_retryable)
     async def get(
@@ -142,14 +149,14 @@ class ElogClient:
             AuthenticationError: If authentication fails
         """
         url = f"{self.base_url}{endpoint}"
-        headers = await self._get_auth_headers() if require_auth else {}
+        headers = self._get_auth_headers() if require_auth else {}
         response = await self._session.get(url, headers=headers, params=params)
 
         # On 401, refresh the Kerberos ticket and retry once
         if response.status_code == 401 and require_auth:
             logger.debug(f"Got 401 for {endpoint}, refreshing auth headers")
             self._auth_headers = None
-            headers = await self._get_auth_headers()
+            headers = self._get_auth_headers()
             response = await self._session.get(url, headers=headers, params=params)
             if response.status_code == 401:
                 raise AuthenticationError(
@@ -181,7 +188,9 @@ class ElogClient:
             Validated Pydantic model instance
         """
         url = endpoint.url(**path_params)
-        data = await self.get(url, params=params, require_auth=endpoint.require_auth)
+        data = await self.get(
+            url, params=params, require_auth=endpoint.require_auth
+        )
         return endpoint.model.model_validate(data)
 
     async def get_files(self, experiment_id: str) -> FilesResponse:

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -1,0 +1,36 @@
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from gssapi.raw import GSSError
+
+from elogfetch.api.client import ElogClient
+from elogfetch.exceptions import AuthenticationError
+
+# GSS_S_NO_CRED (0xD0000) — "no credentials available"
+_NO_CRED = GSSError(851968, 0)
+
+
+def test_kinit_fails_raises_authentication_error():
+    """When there's no ticket and kinit itself fails, AuthenticationError is raised."""
+    with (
+        patch("elogfetch.api.client._get_negotiate_token", side_effect=_NO_CRED),
+        patch(
+            "elogfetch.api.client.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "kinit"),
+        ),
+    ):
+        client = ElogClient()
+        with pytest.raises(AuthenticationError, match="kinit"):
+            client._get_auth_headers()
+
+
+def test_kinit_succeeds_then_gss_fails_raises_authentication_error():
+    """When kinit runs but token generation still fails, AuthenticationError is raised."""
+    with (
+        patch("elogfetch.api.client._get_negotiate_token", side_effect=_NO_CRED),
+        patch("elogfetch.api.client.subprocess.run"),
+    ):
+        client = ElogClient()
+        with pytest.raises(AuthenticationError, match="after kinit"):
+            client._get_auth_headers()


### PR DESCRIPTION
this workaround for not including a key dependency (lcls-krtc) in our repo dependency list involves creating a local conda/mamba environment in the root dir of this repo, and enabling the build of `gssapi` by providing it with environment variables pointing to `krb5-config` binary and system `libgssapi_krb5.so` . 

we also simplify the client code a bit and add back a sync client so that none of the other things stop working after this stack is merged

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #13 
- <kbd>&nbsp;10&nbsp;</kbd> #12 
- <kbd>&nbsp;9&nbsp;</kbd> #11 
- <kbd>&nbsp;8&nbsp;</kbd> #10 
- <kbd>&nbsp;7&nbsp;</kbd> #9 
- <kbd>&nbsp;6&nbsp;</kbd> #8 
- <kbd>&nbsp;5&nbsp;</kbd> #7 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #6 
- <kbd>&nbsp;3&nbsp;</kbd> #5 
- <kbd>&nbsp;2&nbsp;</kbd> #3 
- <kbd>&nbsp;1&nbsp;</kbd> #2 
<!-- GitButler Footer Boundary Bottom -->

