### PR TITLE
add some precommit hooks using `prek`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The database is stored as `elog_YYYY_MMDD_HHMM.db` with the following tables:
 
 ```bash
 uv sync
+uv run prek install
 
 # Run tests (use python -m to ensure correct interpreter)
 uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "prek>=0.3.3",
     "pytest>=8.4.2",
     "pytest-cov>=7.0.0",
     "ruff>=0.15.1",


### PR DESCRIPTION
prek added to deps (later commit in this stack pins everything with uv.lock), so that we are doing our formatting/checking prior to committing

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #13 
- <kbd>&nbsp;10&nbsp;</kbd> #12 
- <kbd>&nbsp;9&nbsp;</kbd> #11 
- <kbd>&nbsp;8&nbsp;</kbd> #10 
- <kbd>&nbsp;7&nbsp;</kbd> #9 
- <kbd>&nbsp;6&nbsp;</kbd> #8 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #7 
- <kbd>&nbsp;4&nbsp;</kbd> #6 
- <kbd>&nbsp;3&nbsp;</kbd> #5 
- <kbd>&nbsp;2&nbsp;</kbd> #3 
- <kbd>&nbsp;1&nbsp;</kbd> #2 
<!-- GitButler Footer Boundary Bottom -->

