### PR TITLE
strip `from __future__ import annotations`

### DIFF
--- a/src/elogfetch/__init__.py
+++ b/src/elogfetch/__init__.py
@@ -1,7 +1,5 @@
 """elogfetch: Fetch LCLS experiment data from the electronic logbook."""
 
-from __future__ import annotations
-
 from .api import ElogClient
 from .config import Config
 from .exceptions import (

--- a/src/elogfetch/api/__init__.py
+++ b/src/elogfetch/api/__init__.py
@@ -1,7 +1,5 @@
 """API client and modules for fetching elog data."""
 
-from __future__ import annotations
-
 from .client import ElogClient
 from .experiments import fetch_updated_experiments
 from .file_manager import fetch_file_manager

--- a/src/elogfetch/api/client.py
+++ b/src/elogfetch/api/client.py
@@ -1,10 +1,8 @@
 """HTTP client with Kerberos authentication for SLAC elog API."""
 
-from __future__ import annotations
-
 import base64
 import subprocess
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 import gssapi
 import httpx
@@ -83,7 +81,7 @@ class ElogClient:
         self._session = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
         self._sync_session = httpx.Client(timeout=REQUEST_TIMEOUT)
 
-    async def __aenter__(self) -> ElogClient:
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, *args: object) -> None:

--- a/src/elogfetch/api/experiments.py
+++ b/src/elogfetch/api/experiments.py
@@ -1,7 +1,5 @@
 """Fetch list of recently updated experiments."""
 
-from __future__ import annotations
-
 import re
 
 from ..utils import get_logger

--- a/src/elogfetch/api/file_manager.py
+++ b/src/elogfetch/api/file_manager.py
@@ -1,7 +1,5 @@
 """Fetch file manager data for an experiment."""
 
-from __future__ import annotations
-
 from collections import defaultdict
 from typing import Any
 

--- a/src/elogfetch/api/gen/endpoint.py
+++ b/src/elogfetch/api/gen/endpoint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel

--- a/src/elogfetch/api/gen/endpoint_models.py
+++ b/src/elogfetch/api/gen/endpoint_models.py
@@ -18,8 +18,6 @@ Usage::
     endpoint = ENDPOINT_MODELS.get("/lgbk/{experiment_name}/ws/runs")
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from .endpoint import Endpoint

--- a/src/elogfetch/api/info.py
+++ b/src/elogfetch/api/info.py
@@ -1,7 +1,5 @@
 """Fetch experiment information."""
 
-from __future__ import annotations
-
 import re
 from typing import Any
 

--- a/src/elogfetch/api/logbook.py
+++ b/src/elogfetch/api/logbook.py
@@ -1,7 +1,5 @@
 """Fetch logbook entries for an experiment."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from ..exceptions import APIError

--- a/src/elogfetch/api/questionnaire.py
+++ b/src/elogfetch/api/questionnaire.py
@@ -1,7 +1,5 @@
 """Fetch questionnaire data for an experiment."""
 
-from __future__ import annotations
-
 import re
 from typing import Any
 

--- a/src/elogfetch/api/runtable.py
+++ b/src/elogfetch/api/runtable.py
@@ -1,7 +1,5 @@
 """Fetch run table data for an experiment."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from ..exceptions import APIError

--- a/src/elogfetch/api/workflow.py
+++ b/src/elogfetch/api/workflow.py
@@ -1,7 +1,5 @@
 """Fetch workflow definitions for an experiment."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from ..exceptions import APIError

--- a/src/elogfetch/cli.py
+++ b/src/elogfetch/cli.py
@@ -1,7 +1,5 @@
 """Command-line interface for elogfetch."""
 
-from __future__ import annotations
-
 import json
 import logging
 import queue

--- a/src/elogfetch/config.py
+++ b/src/elogfetch/config.py
@@ -1,12 +1,10 @@
 """Configuration management for elogfetch."""
 
-from __future__ import annotations
-
 import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import yaml
 
@@ -40,7 +38,7 @@ class Config:
         cls,
         config_file: Path | None = None,
         cli_args: dict[str, Any] | None = None,
-    ) -> Config:
+    ) -> Self:
         """Load config with precedence: CLI > env > file > defaults."""
         config = cls()
 
@@ -58,7 +56,7 @@ class Config:
         return config
 
     @classmethod
-    def _merge_yaml(cls, config: Config, config_file: Path) -> Config:
+    def _merge_yaml(cls, config: Self, config_file: Path) -> Self:
         """Merge configuration from YAML file."""
         with open(config_file) as f:
             data = yaml.safe_load(f)
@@ -84,7 +82,7 @@ class Config:
         return config
 
     @classmethod
-    def _merge_env(cls, config: Config) -> Config:
+    def _merge_env(cls, config: Self) -> Self:
         """Merge configuration from environment variables."""
         if val := os.environ.get("FETCH_ELOG_HOURS_LOOKBACK"):
             config.hours_lookback = float(val)
@@ -102,7 +100,7 @@ class Config:
         return config
 
     @classmethod
-    def _merge_cli(cls, config: Config, cli_args: dict[str, Any]) -> Config:
+    def _merge_cli(cls, config: Self, cli_args: dict[str, Any]) -> Self:
         """Merge configuration from CLI arguments."""
         if cli_args.get("hours") is not None:
             config.hours_lookback = float(cli_args["hours"])

--- a/src/elogfetch/exceptions.py
+++ b/src/elogfetch/exceptions.py
@@ -1,7 +1,5 @@
 """Custom exceptions for elogfetch."""
 
-from __future__ import annotations
-
 
 class FetchElogError(Exception):
     """Base exception for elogfetch."""

--- a/src/elogfetch/storage/__init__.py
+++ b/src/elogfetch/storage/__init__.py
@@ -1,7 +1,5 @@
 """Database storage for elogfetch."""
 
-from __future__ import annotations
-
 from .database import Database, find_latest_database, generate_db_name
 from .models import (
     PI,

--- a/src/elogfetch/storage/database.py
+++ b/src/elogfetch/storage/database.py
@@ -1,7 +1,5 @@
 """SQLite database operations for elogfetch."""
 
-from __future__ import annotations
-
 import json
 import sqlite3
 from datetime import datetime

--- a/src/elogfetch/storage/schema.py
+++ b/src/elogfetch/storage/schema.py
@@ -1,7 +1,5 @@
 """Alembic configuration helper for elogfetch SQLModel models."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from alembic.config import Config

--- a/src/elogfetch/utils/__init__.py
+++ b/src/elogfetch/utils/__init__.py
@@ -1,7 +1,5 @@
 """Utility functions for elogfetch."""
 
-from __future__ import annotations
-
 from .locking import acquire_lock
 from .logging import get_logger, setup_logging
 

--- a/src/elogfetch/utils/locking.py
+++ b/src/elogfetch/utils/locking.py
@@ -1,7 +1,5 @@
 """File locking utilities for elogfetch."""
 
-from __future__ import annotations
-
 import fcntl
 from collections.abc import Generator
 from contextlib import contextmanager

--- a/src/elogfetch/utils/logging.py
+++ b/src/elogfetch/utils/logging.py
@@ -1,7 +1,5 @@
 """Logging setup for elogfetch."""
 
-from __future__ import annotations
-
 import logging
 import sys
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Shared fixtures for elogfetch tests."""
 
-from __future__ import annotations
-
 import pytest
 
 

--- a/tests/test_api_transforms.py
+++ b/tests/test_api_transforms.py
@@ -1,7 +1,5 @@
 """Tests for API data transformation functions."""
 
-from __future__ import annotations
-
 from elogfetch.api.experiments import _filter_experiments
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,5 @@
 """Tests for configuration loading."""
 
-from __future__ import annotations
-
 import os
 from pathlib import Path
 from unittest import mock

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,5 @@
 """Tests for database operations."""
 
-from __future__ import annotations
-
 import sqlite3
 
 from elogfetch.storage.database import Database

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,7 +1,5 @@
 """Tests for file locking utilities."""
 
-from __future__ import annotations
-
 import pytest
 
 from elogfetch.exceptions import LockError


### PR DESCRIPTION
these are not necessary for all of these files. python 3.9 can’t handle ` | `, but 3.10 can. they are still necessary for forward references. we should upgrade the python version to 3.13 or 3.14, and then we can get rid of these altogether. no need to stick to a low python version for this app IMO.

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #13 
- <kbd>&nbsp;10&nbsp;</kbd> #12 
- <kbd>&nbsp;9&nbsp;</kbd> #11 
- <kbd>&nbsp;8&nbsp;</kbd> #10 
- <kbd>&nbsp;7&nbsp;</kbd> #9 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #8 
- <kbd>&nbsp;5&nbsp;</kbd> #7 
- <kbd>&nbsp;4&nbsp;</kbd> #6 
- <kbd>&nbsp;3&nbsp;</kbd> #5 
- <kbd>&nbsp;2&nbsp;</kbd> #3 
- <kbd>&nbsp;1&nbsp;</kbd> #2 
<!-- GitButler Footer Boundary Bottom -->

